### PR TITLE
Fixed foreigner sorting at "leaderboard" page

### DIFF
--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -47,7 +47,7 @@
                 <select class="simple-banner-select" @change="LoadLeaderboard(sort, mode, mods, $event.target.value)">
                     <option value="global">Todos Estados</option>
                     <!-- Talvez popular essa lista de opcoes com um request no futuro -->
-                    <option value="zz">Estrangeiro</option>
+                    <option value="xx">Estrangeiro</option>
                     <option value="a1">Acre</option>
                     <option value="a2">Alagoas</option>
                     <option value="a3">Amapá</option>


### PR DESCRIPTION
Now, clicking on "Estrangeiro" actually redirects to sorting by country "xx"
![image](https://github.com/nekoraw/guweb/assets/89195562/6e2fc377-94bb-43a7-a0c1-8a067f717951)
